### PR TITLE
Suppress error member_function_call_bad_type in .clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,3 @@
+Diagnostics:
+  Suppress:
+    - member_function_call_bad_type


### PR DESCRIPTION
Doesn't cause a problem in actual compilation